### PR TITLE
Add default SF12 CAD parameters for SX126x

### DIFF
--- a/sx126x/apps/cad/main_cad.c
+++ b/sx126x/apps/cad/main_cad.c
@@ -263,6 +263,11 @@ static void optimize_cad_parameters( sx126x_lora_sf_t sf, sx126x_cad_params_t* c
         cad_params->cad_detect_peak = 25;
         cad_params->cad_symb_nb     = 4;
         break;
+    case SX126X_LORA_SF12:
+        cad_params->cad_detect_min  = 10;
+        cad_params->cad_detect_peak = 28;
+        cad_params->cad_symb_nb     = 4;
+        break;
     default:
         HAL_DBG_TRACE_WARNING( "CAD may not function properly while using these radio parameters\n" );
         break;


### PR DESCRIPTION
Additions using values added to [AN1200.48: LoRa Channel Activity Detection (CAD) with SX126x](https://semtech.my.salesforce.com/sfc/p/E0000000JelG/a/3n000000qSr3/s723KzQi7zXFhBPKqesoF11.MtwYu6B8pdEQcmInlkE).
Revision to document noted by 

> Revision History: Version 2.1 (November 2019) Add SF12 operation {...}

The [README](sx126x/apps/cad/README.md) says the possible values for `CAD_DETECT_PEAK` are `[22-25]`, but this isn't true, a much larger range works.

The _optimal settings_ are optimised for specifically a bandwidth of 125 kHz, this isn't made clear.